### PR TITLE
Migrate to manifest V3

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "__MSG_extensionName__",
   "version": "version will be mapped from package.json",
 


### PR DESCRIPTION
I was looking into the migration, and it turns out all you need to do is change the manifest version.
ref: https://developer.chrome.com/docs/extensions/develop/migrate?hl=ja